### PR TITLE
Make `String#contains(regex)` throw

### DIFF
--- a/contains.js
+++ b/contains.js
@@ -2,6 +2,7 @@
 if (!String.prototype.contains) {
 	(function() {
 		'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
+		var toString = {}.toString;
 		var defineProperty = (function() {
 			// IE 8 only supports `Object.defineProperty` on DOM elements
 			try {
@@ -17,6 +18,9 @@ if (!String.prototype.contains) {
 				throw TypeError();
 			}
 			var string = String(this);
+			if (search && toString.call(search) == '[object RegExp]') {
+				throw TypeError();
+			}
 			var stringLength = string.length;
 			var searchString = String(search);
 			var searchLength = searchString.length;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -74,11 +74,11 @@ assertEquals('abc123def'.contains(9, 5), false);
 assertEquals('abc123def'.contains(9, +Infinity), false);
 
 assertEquals('foo[a-z]+(bar)?'.contains('[a-z]+'), true);
-assertEquals('foo[a-z]+(bar)?'.contains(/[a-z]+/), false);
-assertEquals('foo/[a-z]+/(bar)?'.contains(/[a-z]+/), true);
+assertThrows(function() { 'foo[a-z]+(bar)?'.contains(/[a-z]+/); }, TypeError);
+assertThrows(function() { 'foo/[a-z]+/(bar)?'.contains(/[a-z]+/); }, TypeError);
 assertEquals('foo[a-z]+(bar)?'.contains('(bar)?'), true);
-assertEquals('foo[a-z]+(bar)?'.contains(/(bar)?/), false);
-assertEquals('foo[a-z]+/(bar)?/'.contains(/(bar)?/), true);
+assertThrows(function() { 'foo[a-z]+(bar)?'.contains(/(bar)?/); }, TypeError);
+assertThrows(function() { 'foo[a-z]+/(bar)?/'.contains(/(bar)?/); }, TypeError);
 
 // http://mathiasbynens.be/notes/javascript-unicode#poo-test
 var string = 'I\xF1t\xEBrn\xE2ti\xF4n\xE0liz\xE6ti\xF8n\u2603\uD83D\uDCA9';
@@ -101,6 +101,8 @@ assertEquals(String.prototype.contains.call(42, '2', 4), false);
 assertEquals(String.prototype.contains.call({ 'toString': function() { return 'abc'; } }, 'b', 0), true);
 assertEquals(String.prototype.contains.call({ 'toString': function() { return 'abc'; } }, 'b', 1), true);
 assertEquals(String.prototype.contains.call({ 'toString': function() { return 'abc'; } }, 'b', 2), false);
+assertThrows(function() { String.prototype.contains.call({ 'toString': function() { throw RangeError(); } }, /./); }, RangeError);
+assertThrows(function() { String.prototype.contains.call({ 'toString': function() { return 'abc'; } }, /./); }, TypeError);
 
 assertThrows(function() { String.prototype.contains.apply(undefined); }, TypeError);
 assertThrows(function() { String.prototype.contains.apply(undefined, ['b']); }, TypeError);
@@ -114,3 +116,5 @@ assertEquals(String.prototype.contains.apply(42, ['2', 4]), false);
 assertEquals(String.prototype.contains.apply({ 'toString': function() { return 'abc'; } }, ['b', 0]), true);
 assertEquals(String.prototype.contains.apply({ 'toString': function() { return 'abc'; } }, ['b', 1]), true);
 assertEquals(String.prototype.contains.apply({ 'toString': function() { return 'abc'; } }, ['b', 2]), false);
+assertThrows(function() { String.prototype.contains.apply({ 'toString': function() { throw RangeError(); } }, [/./]); }, RangeError);
+assertThrows(function() { String.prototype.contains.apply({ 'toString': function() { return 'abc'; } }, [/./]); }, TypeError);


### PR DESCRIPTION
This was a spec bug that is finally fixed in rev23 of the ES6 draft as per https://bugs.ecmascript.org/show_bug.cgi?id=2407.

I’ll merge this as soon as the new draft gets published so I can confirm whether this is the correct order of operations. (I assume it is, since this matches `String#{starts,ends}With`.)
